### PR TITLE
kicad-pretty-git: Increased maximum number of repositories from 100 to 200

### DIFF
--- a/kicad-pretty-git/PKGBUILD
+++ b/kicad-pretty-git/PKGBUILD
@@ -6,7 +6,8 @@
   # intelligent, such that it will remove orphaned repos.
 
 if [ -x /usr/bin/curl ]; then
-  PRETTY_REPOS=(`curl -s https://api.github.com/orgs/KiCad/repos?per_page=2000 2> /dev/null \
+  PRETTY_REPOS=(`curl -s "https://api.github.com/orgs/KiCad/repos?per_page=100&page=1" \
+    "https://api.github.com/orgs/KiCad/repos?per_page=100&page=2" 2> /dev/null \
     | grep full_name | grep pretty \
     | sed -r  's:.+ "KiCad/(.+)",:\1:'`)
   PRETTY_SRC=(${PRETTY_REPOS[@]/%/.git})


### PR DESCRIPTION
This fixes the issue where the TO_SOT_Packages_SMD.pretty repo isn't cloned.
